### PR TITLE
working but with limitations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.idea
 *.DS_Store
 *node_modules

--- a/proj1/package.json
+++ b/proj1/package.json
@@ -10,6 +10,7 @@
     "express": "^4.13.3",
     "file-loader": "^0.8.4",
     "node-sass": "^3.3.3",
+    "omit-tilde-webpack-plugin": "^0.0.7",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.0",
     "redbox-react": "^1.1.1",

--- a/proj1/webpack.config.js
+++ b/proj1/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
     loaders: [
       { test: /\.js$/, loader: "babel", exclude: /(node_modules|bower_components)/ },
       { test: /\.coffee$/, loader: "babel!coffee" },
-      { test: /\.scss$/, loader: "style!css!resolve-url!sass?sourceMap" },
+      { test: /\.scss$/, loader: "style!css!resolve-url?absolute!sass?sourceMap" },
       { test: /\.(svg|png|jpe?g|ttf|woff2?|eot)$/, loader: 'url?limit=8182' }
     ]
   },

--- a/proj1/webpack.config.js
+++ b/proj1/webpack.config.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var webpack = require('webpack');
+var OmitTildeWebpackPlugin = require('omit-tilde-webpack-plugin');
 
 module.exports = {
   devtool: 'eval',
@@ -9,29 +10,27 @@ module.exports = {
   ],
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: 'bundle.js',
+    filename: 'bundle.js'
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin()
+    new webpack.NoErrorsPlugin(),
+    new OmitTildeWebpackPlugin({
+      include: ['package.json', 'proj1', 'proj2'],
+      deprecate: true
+    })
   ],
   module: {
     loaders: [
       { test: /\.js$/, loader: "babel", exclude: /(node_modules|bower_components)/ },
       { test: /\.coffee$/, loader: "babel!coffee" },
-      { test: /\.scss$/, loader: "style!css!resolve-url!sass" },
+      { test: /\.scss$/, loader: "style!css!resolve-url!sass?sourceMap" },
       { test: /\.(svg|png|jpe?g|ttf|woff2?|eot)$/, loader: 'url?limit=8182' }
-    ]
-  },
-  sassLoader: {
-    includePaths: [
-      path.resolve(".."),
-      path.resolve("node_modules")
     ]
   },
   resolve: {
     root: [
-      path.resolve('..'),
+      path.resolve('..')
     ],
     modulesDirectories: [
       'node_modules'

--- a/proj2/other.scss
+++ b/proj2/other.scss
@@ -1,5 +1,5 @@
 .javascript {
   height: 200px;
   width: 200px;
-  background-image: url(proj2/javascript.png)
+  background-image: url(./javascript.png)
 }

--- a/proj2/other.scss
+++ b/proj2/other.scss
@@ -1,5 +1,5 @@
 .javascript {
   height: 200px;
   width: 200px;
-  background-image: url(./javascript.png)
+  background-image: url(proj2/javascript.png);
 }


### PR DESCRIPTION
@ccorcos this is working but I had to use `absolute` mode on the `resolve-url-loader`. But check the diff because there were several changes.

With this example project I can see some interesting things.

I had forgotten that the project directory, per `process.cwd()` was intended as a stop to the file search where there was no `package.json` or `bower.json` encountered. Since your script is running inside `proj1` then any references in `proj2` would not have worked. However there is a bug at [line 102](https://github.com/bholloway/resolve-url-loader/blob/master/lib/find-file.js#L102) which means that this did not effect you. Obviously I will need to relax the original intention and work out some other search limit.

I now need to work out why the `absolute` mode is necessary. We actually want `url(proj2/javascript.png)` to go through unchanged so that webpack can treat it as a module uri. But when this happens Webpack cannot resolve it.
