### PR TITLE
fixed issue with url module not found

### DIFF
--- a/proj1/webpack.config.js
+++ b/proj1/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
     loaders: [
       { test: /\.js$/, loader: "babel", exclude: /(node_modules|bower_components)/ },
       { test: /\.coffee$/, loader: "babel!coffee" },
-      { test: /\.scss$/, loader: "style!css!sass?sourceMap" },
+      { test: /\.scss$/, loader: "style!css!sass" },
       { test: /\.(svg|png|jpe?g|ttf|woff2?|eot)$/, loader: 'url?limit=8182' }
     ]
   },

--- a/proj1/webpack.config.js
+++ b/proj1/webpack.config.js
@@ -24,16 +24,18 @@ module.exports = {
     loaders: [
       { test: /\.js$/, loader: "babel", exclude: /(node_modules|bower_components)/ },
       { test: /\.coffee$/, loader: "babel!coffee" },
-      { test: /\.scss$/, loader: "style!css!resolve-url?absolute!sass?sourceMap" },
+      { test: /\.scss$/, loader: "style!css!sass?sourceMap" },
       { test: /\.(svg|png|jpe?g|ttf|woff2?|eot)$/, loader: 'url?limit=8182' }
     ]
   },
   resolve: {
-    root: [
-      path.resolve('..')
-    ],
     modulesDirectories: [
-      'node_modules'
+      'node_modules', path.resolve('..')
+    ]
+  },
+  resolveLoader: {
+    modulesDirectories: [
+      path.resolve('node_modules')
     ]
   }
 };


### PR DESCRIPTION
Wow @ccorcos I found the real issue.

Let me just say that given you and I and people like us are migrating to Webpack and helping each other out the problem, by definition, is that we are all still learning Webpack. So sorry that I did not see this earlier.

The final error we have been facing was something like:

```
Module not found: Error: Cannot resolve module 'url' in .../webpack-sass-url-issue/proj2
```

What bothered me this whole time was why the error was not more descriptive. Why, for example, could it not just tell me the content of the `url()` statement that it was trying to find. I finally realised that it is not the asset it cannot find, it is the `url-loader`!

This PR shows the minimum I needed to make this work. You actually don't need `resolve-url-loader` or the `resolve.root`. You may well do for your actual project, I do not know.
